### PR TITLE
[limits] Be able to set a custom timeout to not wait for tile fetching after a timeout fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Changlog
+# Changelog
+
+## 2.3.1-cdb3 (not released)
+
+ - Do not wait for tile fetching after timeout fires
 
 ## 2.3.1-cdb2
 

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function Bridge(uri, callback) {
         if (typeof source._uri.limits.render === 'undefined') source._uri.limits.render = 0;
 
         if (source._uri.limits.render > 0) {
-            source.getTile = timeoutDecorator.method(source.getTile, source, source._uri.limits.render);
+            source.getTile = timeoutDecorator(source.getTile.bind(source), source._uri.limits.render);
         }
 
         if (callback) source.once('open', callback);

--- a/test/test.js
+++ b/test/test.js
@@ -648,7 +648,7 @@ function compare_vtiles(assert,filepath,vtile1,vtile2) {
             tape('should timeout ' + source + ' (' + test.coords + ') using limits.render ' + timeout, function (assert) {
                 sources[source].getTile(z,x,y, function(err, buffer, headers) {
                     assert.ok(err);
-                    assert.equal(err.message, 'Timeout of ' + timeout + 'ms exceeded');
+                    assert.equal(err.message, 'Render timed out');
                     assert.end();
                 });
             });

--- a/utils/timeout-decorator.js
+++ b/utils/timeout-decorator.js
@@ -1,4 +1,4 @@
-module.exports = function timeoutMethodDecorator(fn, ms) {
+module.exports = function timeoutDecorator(fn, ms) {
   return function () {
     var timeout = false;
     var args = [].slice.call(arguments, 0, arguments.length - 1);

--- a/utils/timeout-decorator.js
+++ b/utils/timeout-decorator.js
@@ -1,0 +1,23 @@
+exports.method = function timeoutMethodDecorator(method, context, ms) {
+  return function () {
+    var timeout = false;
+    var args = [].slice.call(arguments, 0, arguments.length - 1);
+    var callback = arguments[arguments.length - 1];
+
+    var timeoutId = setTimeout(function(){
+      timeout = true;
+      var err = new Error('Timeout of ' + ms + 'ms exceeded');
+      callback(err);
+    }, ms);
+
+    args.push(function decoratorCallback () {
+      if (timeout) {
+        return;
+      }
+      clearTimeout(timeoutId);
+      callback.apply(null, arguments);
+    })
+
+    method.apply(context, args);
+  }
+}

--- a/utils/timeout-decorator.js
+++ b/utils/timeout-decorator.js
@@ -6,7 +6,7 @@ module.exports = function timeoutDecorator(fn, ms) {
 
     var timeoutId = setTimeout(function () {
       timeout = true;
-      var err = new Error('Timeout of ' + ms + 'ms exceeded');
+      var err = new Error('Render timed out');
       callback(err);
     }, ms);
 

--- a/utils/timeout-decorator.js
+++ b/utils/timeout-decorator.js
@@ -1,10 +1,10 @@
-exports.method = function timeoutMethodDecorator(method, context, ms) {
+module.exports = function timeoutMethodDecorator(fn, ms) {
   return function () {
     var timeout = false;
     var args = [].slice.call(arguments, 0, arguments.length - 1);
     var callback = arguments[arguments.length - 1];
 
-    var timeoutId = setTimeout(function(){
+    var timeoutId = setTimeout(function () {
       timeout = true;
       var err = new Error('Timeout of ' + ms + 'ms exceeded');
       callback(err);
@@ -18,6 +18,6 @@ exports.method = function timeoutMethodDecorator(method, context, ms) {
       callback.apply(null, arguments);
     })
 
-    method.apply(context, args);
+    fn.apply(null, args);
   }
 }


### PR DESCRIPTION
# Context

After releasing vector rendering we use more and more `.mvt` tiles, some of them could take too long to be fetched and in order to ensure platform stability we need to, as per we did in `tilelive-mapnik`, implement a timeout mechanism to not wait for mapnik render a tile.

# Things to do

- [x] While fetching tiles (.mvt), receive a timeout parameter and use it in the same way we do in `tilelive-mapnik`.
