### PR TITLE
Add zoom, x, y and bbox variables to opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,7 +280,13 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
     opts.strictly_simple = true;
 
     // make zoom_level variable available to mapnik postgis datasource
-    opts.variables = { "zoom_level": z };
+    opts.variables = {
+        zoom_level: z, // for backwards compatibility
+        zoom: z,
+        x: x,
+        y: y,
+        bbox: JSON.stringify(map.extent)
+    };
 
     map.render(vtile, opts, function(err, vtile) {
         source._map.release(map);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     }
   ],
   "dependencies": {
-    "mapnik": "~3.5.0",
+    "mapnik": "cartodb/node-mapnik#3.5.x-mvt-variables",
     "sphericalmercator": "1.0.x",
     "mapnik-pool": "~0.1.3"
   },


### PR DESCRIPTION
Add some variables to be used later on by mapnik postgis input for token
substitution.

This code is now similar to what we do in `tilelive-mapnik`: https://github.com/cartodb/tilelive-mapnik/blob/query-variables/lib/render.js#L194

@javisantana and @Algunenano can you please take a quick look?