### PR TITLE
Remove error on empty tile

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -2,6 +2,7 @@
 
 ## 2.5.1-cdb10
  - Update or remove dev dependencies.
+ - **Remove error on empty tile**. Instead an empty buffer is returned. For MVTs the `x-tilelive-contains-data` header will still be set to false.
 
 ## 2.5.1-cdb9
  - Set @carto/mapnik to [`3.6.2-carto.10`](https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto/CHANGELOG.carto.md#362-carto10)

--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ Bridge.getRaster = function(source, map, im, z, x, y, callback) {
 
             // If source is in blank mode any solid tile is empty.
             if (solid && source._blank) {
-                return callback(err, new Buffer(0));
+                return callback(null, new Buffer(0));
             }
 
             var pixel_key = '';

--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ Bridge.getRaster = function(source, map, im, z, x, y, callback) {
 
             // If source is in blank mode any solid tile is empty.
             if (solid && source._blank) {
-                return callback(new Error('Tile does not exist'));
+                return callback(err, new Buffer(0));
             }
 
             var pixel_key = '';
@@ -300,7 +300,7 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
         }
         headers['x-tilelive-contains-data'] = vtile.painted();
         if (vtile.empty()) {
-            return callback(new Error('Tile does not exist'), null, headers);
+            return callback(null, new Buffer(0), headers);
         }
         vtile.getData({ compression: source._gzip ? 'gzip' : 'none' }, function(err, pbfz) {
             if (err) {

--- a/test/bench-vector.test.js
+++ b/test/bench-vector.test.js
@@ -35,8 +35,8 @@ tape('vector bench deferred', function(assert) {
     }
     function getTile(z, x, y, done) {
         source.getTile(z, x, y, function(err, buffer) {
-            if (err) {
-                assert.equal(err.message, 'Tile does not exist', z + '/' + x + '/' + y);
+            assert.ok(!err, err);
+            if (!buffer.length) {
                 empty++;
                 done(null, buffer);
             } else {
@@ -45,7 +45,7 @@ tape('vector bench deferred', function(assert) {
                     assert.ifError(err, z + '/' + x + '/' + y);
                     done(null, buffer)
                 });
-            }   
+            }
         });
     }
     q.awaitAll(function(err, res) {
@@ -97,8 +97,8 @@ tape('vector bench auto', function(assert) {
     }
     function getTile(z, x, y, done) {
         source.getTile(z, x, y, function(err, buffer) {
-            if (err) {
-                assert.equal(err.message, 'Tile does not exist', z + '/' + x + '/' + y);
+            assert.ok(!err, err);
+            if (!buffer.length) {
                 empty++;
                 done(null, buffer);
             } else {
@@ -156,8 +156,8 @@ tape('vector bench async', function(assert) {
     }
     function getTile(z, x, y, done) {
         source.getTile(z, x, y, function(err, buffer) {
-            if (err) {
-                assert.equal(err.message, 'Tile does not exist', z + '/' + x + '/' + y);
+            assert.ok(!err, err);
+            if (!buffer.length) {
                 empty++;
                 done(null, buffer);
             } else {
@@ -166,7 +166,7 @@ tape('vector bench async', function(assert) {
                     assert.ifError(err, z + '/' + x + '/' + y);
                     done(null, buffer)
                 });
-            }   
+            }
         });
     }
     q.awaitAll(function(err, res) {

--- a/test/test.js
+++ b/test/test.js
@@ -272,7 +272,7 @@ function compare_vtiles(assert,filepath,vtile1,vtile2) {
                 sources[source].getTile(z,x,y, function(err, buffer, headers) {
                     // Test that empty tiles are so.
                     if (obj.empty) {
-                        assert.equal(err.message, 'Tile does not exist');
+                        assert.equal(buffer.length, 0);
                         assert.equal(headers['x-tilelive-contains-data'], false);
                         return assert.end();
                     }
@@ -347,7 +347,7 @@ function compare_vtiles(assert,filepath,vtile1,vtile2) {
                 sources[source].getTile(z,x,y, function(err, buffer, headers) {
                     // Test that empty tiles are so.
                     if (obj.empty) {
-                        assert.equal(err.message, 'Tile does not exist');
+                        assert.equal(buffer.length, 0);
                         return assert.end();
                     }
 


### PR DESCRIPTION
Instead of returning an error (`'Tile does not exist'`), return an empty buffer when the MVT is empty.