### PR TITLE
Use strict mode

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -1,5 +1,8 @@
 # CARTO tilelive-bridge changelog
 
+## 2.5.1-cdb11
+ - Make all modules to use strict mode semantics.
+
 ## 2.5.1-cdb10
  - Update or remove dev dependencies.
  - **Remove error on empty tile**. Instead an empty buffer is returned. For MVTs the `x-tilelive-contains-data` header will still be set to false.

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var url = require('url');
 var path = require('path');
 var mapnik = require('@carto/mapnik');

--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ var ImagePool = function(size) {
         return callback(null,new mapnik.Image(size,size));
     }
     function destroy(im) {
-        delete im;
+        // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Delete_in_strict_mode
+        im = null;
     }
 }
 

--- a/test/bench-raster.test.js
+++ b/test/bench-raster.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Bridge = require('..');
 var path = require('path');
 var fs = require('fs');
@@ -51,4 +53,3 @@ tape('raster bench', function(assert) {
         })
     });
 });
-

--- a/test/bench-vector.test.js
+++ b/test/bench-vector.test.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 var tape = require('tape');
 var queue = require('queue-async');
 
-var source_deferred;
+var source;
 var rate_deferred;
 var rate_auto;
 
@@ -175,7 +175,7 @@ tape('vector bench async', function(assert) {
         assert.ifError(err);
         source.close(function() {
             time = +(new Date()) - time;
-            rate_async = total/(time/1000);
+            var rate_async = total/(time/1000);
             // only assert on rate for release builds
             if (process.env.NPM_FLAGS && process.env.NPM_FLAGS.indexOf('--debug') > -1) {
                 console.log("Skipping rate assertion, since we are running in debug mode");

--- a/test/bench-vector.test.js
+++ b/test/bench-vector.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Bridge = require('..');
 var mapnik = require('@carto/mapnik');
 var path = require('path');
@@ -67,7 +69,7 @@ tape('vector bench deferred', function(assert) {
 });
 
 // Currently there is a bug in std::future in xcode that will be fixed in 7.3 release
-// until that point the binaries built in OSX could possibly cause memory corruption 
+// until that point the binaries built in OSX could possibly cause memory corruption
 // when using non deferred processing (like a terrorist) when that is fixed this can be removed.
 if (process.platform != 'darwin') {
 
@@ -107,7 +109,7 @@ tape('vector bench auto', function(assert) {
                     assert.ifError(err, z + '/' + x + '/' + y);
                     done(null, buffer)
                 });
-            }   
+            }
         });
     }
     q.awaitAll(function(err, res) {

--- a/test/close-timeout.test.js
+++ b/test/close-timeout.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Bridge = require('..');
 var path = require('path');
 var fs = require('fs');
@@ -31,4 +33,3 @@ tape('should timeout on close', function(assert) {
         });
     });
 });
-

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Bridge = require('..');
 var path = require('path');
 var fs = require('fs');

--- a/utils/timeout-decorator.js
+++ b/utils/timeout-decorator.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function timeoutDecorator(fn, ms) {
   return function () {
     var timeout = false;


### PR DESCRIPTION
- Use strict
- Avoid Syntax Error in strict mode: Delete of an unqualified identifier in strict mode
- Prevent ReferenceError: rate_async and source are not defined
